### PR TITLE
DSP-22892 Package as gem and deploy to rubygems.org

### DIFF
--- a/fluent-plugin-cloudtrail.gemspec
+++ b/fluent-plugin-cloudtrail.gemspec
@@ -1,8 +1,8 @@
 
 Gem::Specification.new do |s|
   s.name   = 'fluent-plugin-cloudtrail'
-  s.version = '0.0.1'
-  s.date = '2016-12-19'
+  s.version = '0.0.2'
+  s.date = '2017-01-03'
   s.summary = %q{Fluentd input plugin that inputs logs from AWS CloudTrail.}
   s.author = 'Craig Buchanan'
   s.email = 'craig+rubygems@blendlabs.com'
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
     'LICENSE.txt',
     'lib/fluent/plugin/in_cloudtrail.rb'
   ]
-  s.homepage = 'https://github.com/blendlabs/fluent-plugin-cloudtrail'
+  s.homepage = 'https://github.com/blend/fluent-plugin-cloudtrail'
   s.license = 'MIT'
 
   s.add_dependency "fluentd", ">= 0.10.58", "< 2"


### PR DESCRIPTION
Package the cloudtrail fluentd plugin as a gem and deploy to rubygems as fluent-plugin-cloudtrail. Also notify the fluentd plugin project that it exists (http://www.fluentd.org/plugins).